### PR TITLE
Force using grub-pc-bin for ISO even on EFI systems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -445,7 +445,7 @@ $(ISO): $(KERNEL)
 	@echo '    multiboot2 /boot/$(KERNEL)' >> $(ISO_DIR)/boot/grub/grub.cfg
 	@echo '    boot' >> $(ISO_DIR)/boot/grub/grub.cfg
 	@echo '}' >> $(ISO_DIR)/boot/grub/grub.cfg
-	@$(GRUB) -o $(ISO) $(ISO_DIR)
+	@$(GRUB) -d /usr/lib/grub/i386-pc -o $(ISO) $(ISO_DIR)
 
 # Run with QEMU
 run: $(ISO)


### PR DESCRIPTION
Hello!

On UEFI systems, it seems the ISO created is unbootable, with a "Boot failed: Could not read from CDROM (code 0009)" error in qemu.

This seems to be a known issue, (per the last item on https://wiki.osdev.org/Bare_Bones#Frequently_Asked_Questions):

I've worked around it simply, here, by forcing grub to use the correct bootloader binary. There are probably better ways to fix this in the long run, but this should get it working for anyone who wishes to try it out but also happens to be running on a UEFI-enabled system.

Thanks!