### PR TITLE
add missing prototypes to System71StdLib.h

### DIFF
--- a/include/System71StdLib.h
+++ b/include/System71StdLib.h
@@ -37,5 +37,7 @@ int serial_data_ready(void);
 char serial_getchar(void);
 void serial_print_hex(uint32_t value);
 void serial_printf(const char* fmt, ...);
+int sprintf(char* str, const char* format, ...);
+int snprintf(char* str, size_t size, const char* format, ...);
 
 #endif /* SYSTEM71_STDLIB_H */


### PR DESCRIPTION
`SystemInit.c` would not build for me without the prototype `snprintf` defined in `System71StdLib.h`. Add it and `sprintf` to avoid implicit declaration errors.