### PR TITLE
Fix absolute pointer in qemu: Discard PS/2 mouse data when USB absolute pointer is active

### DIFF
--- a/src/Platform/include/input.h
+++ b/src/Platform/include/input.h
@@ -4,6 +4,15 @@
 #include <stdint.h>
 #include "MacTypes.h"
 
+/* Mouse input source selection */
+typedef enum {
+    kMouseSourcePS2,
+    kMouseSourceUSBTablet
+} MouseSource;
+
+void hal_input_set_mouse_source(MouseSource src);
+Boolean hal_input_ps2_mouse_active(void);
+
 void hal_input_poll(void);
 void hal_input_get_mouse(Point* mouse_loc);
 Boolean hal_input_get_keyboard_state(KeyMap key_map);

--- a/src/Platform/x86/hal_input.c
+++ b/src/Platform/x86/hal_input.c
@@ -7,6 +7,17 @@
 #include "Platform/include/input.h"
 #include "PS2Controller.h"
 
+/* Mouse source selection — defaults to PS/2, set once at init */
+static MouseSource g_mouseSource = kMouseSourcePS2;
+
+void hal_input_set_mouse_source(MouseSource src) {
+    g_mouseSource = src;
+}
+
+Boolean hal_input_ps2_mouse_active(void) {
+    return g_mouseSource == kMouseSourcePS2;
+}
+
 /*
  * hal_input_poll - Poll for input events
  *

--- a/src/Platform/x86/ps2.c
+++ b/src/Platform/x86/ps2.c
@@ -10,6 +10,7 @@
 #include "EventManager/EventManager.h"
 #include "Platform/PS2Input.h"
 #include "PS2Controller.h"
+#include "Platform/include/input.h"
 #include <stdint.h>
 #include "Platform/PlatformLogging.h"
 #include <string.h>
@@ -669,6 +670,9 @@ void PollPS2Input(void) {
         uint8_t data = inb(PS2_DATA_PORT);
 
         if (status & PS2_STATUS_AUX) {
+            if (!hal_input_ps2_mouse_active()) {
+                continue;
+            }
             /* --- Mouse byte --- */
             mouse_byte_count++;
             /* PLATFORM_LOG_DEBUG("POLL: Got mouse byte 0x%02x (status=0x%02x) idx=%d enabled=%d count=%d\n",

--- a/src/Platform/x86/xhci.h
+++ b/src/Platform/x86/xhci.h
@@ -7,6 +7,7 @@
 bool xhci_init_x86(void);
 void xhci_poll_hid_x86(void);
 bool xhci_hid_available(void);
+bool xhci_has_absolute_pointer(void);
 bool xhci_msc_available(void);
 OSErr xhci_msc_get_info(uint32_t *block_size, uint64_t *block_count, bool *read_only);
 OSErr xhci_msc_get_info_lun(uint8_t lun, uint32_t *block_size, uint64_t *block_count, bool *read_only);

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,7 @@ extern void DoMenuCommand(short menuID, short item);
 #endif
 
 #include "Platform/include/network.h"
+#include "Platform/include/input.h"
 #if defined(__i386__) || defined(__x86_64__)
 #include "Platform/x86/idt.h"
 #include "Platform/x86/pic.h"
@@ -1863,6 +1864,10 @@ void kernel_main(uint32_t magic, uint32_t* mb2_info) {
         xhci_init_x86();
     } else {
         serial_puts("KERNEL: xHCI HID already present\n");
+    }
+
+    if (xhci_has_absolute_pointer()) {
+        hal_input_set_mouse_source(kMouseSourceUSBTablet);
     }
 
     /* Keep IRQs disabled for now; polling paths are stable. */


### PR DESCRIPTION
This lets you move the pointer in and out of the QEMU window and it ends up in the expected place when using the USB mouse and moving it in and out of the guest window.