### PR TITLE
Fix/xhci USB absolute mouse issues

### DIFF
--- a/src/Platform/include/input.h
+++ b/src/Platform/include/input.h
@@ -4,6 +4,15 @@
 #include <stdint.h>
 #include "MacTypes.h"
 
+/* Mouse input source selection */
+typedef enum {
+    kMouseSourcePS2,
+    kMouseSourceUSBTablet
+} MouseSource;
+
+void hal_input_set_mouse_source(MouseSource src);
+Boolean hal_input_ps2_mouse_active(void);
+
 void hal_input_poll(void);
 void hal_input_get_mouse(Point* mouse_loc);
 Boolean hal_input_get_keyboard_state(KeyMap key_map);

--- a/src/Platform/x86/hal_input.c
+++ b/src/Platform/x86/hal_input.c
@@ -7,6 +7,24 @@
 #include "Platform/include/input.h"
 #include "PS2Controller.h"
 
+extern void serial_puts(const char* str);
+
+/* Mouse source selection — defaults to PS/2, set once at init */
+static MouseSource g_mouseSource = kMouseSourcePS2;
+
+void hal_input_set_mouse_source(MouseSource src) {
+    g_mouseSource = src;
+    if (src == kMouseSourceUSBTablet) {
+        serial_puts("[INPUT] Mouse source set to USB tablet — PS/2 mouse discarded\n");
+    } else {
+        serial_puts("[INPUT] Mouse source set to PS/2\n");
+    }
+}
+
+Boolean hal_input_ps2_mouse_active(void) {
+    return g_mouseSource == kMouseSourcePS2;
+}
+
 /*
  * hal_input_poll - Poll for input events
  *

--- a/src/Platform/x86/ps2.c
+++ b/src/Platform/x86/ps2.c
@@ -10,6 +10,7 @@
 #include "EventManager/EventManager.h"
 #include "Platform/PS2Input.h"
 #include "PS2Controller.h"
+#include "Platform/include/input.h"
 #include <stdint.h>
 #include "Platform/PlatformLogging.h"
 #include <string.h>
@@ -669,6 +670,15 @@ void PollPS2Input(void) {
         uint8_t data = inb(PS2_DATA_PORT);
 
         if (status & PS2_STATUS_AUX) {
+            if (!hal_input_ps2_mouse_active()) {
+                static int ps2_discard_count = 0;
+                ps2_discard_count++;
+                if (ps2_discard_count <= 5 || (ps2_discard_count % 1000) == 0) {
+                    extern void serial_puts(const char* str);
+                    serial_puts("[PS2] Discarding mouse byte (USB tablet active)\n");
+                }
+                continue;
+            }
             /* --- Mouse byte --- */
             mouse_byte_count++;
             /* PLATFORM_LOG_DEBUG("POLL: Got mouse byte 0x%02x (status=0x%02x) idx=%d enabled=%d count=%d\n",

--- a/src/Platform/x86/xhci.c
+++ b/src/Platform/x86/xhci.c
@@ -440,10 +440,10 @@ static bool xhci_poll_cmd_complete(uintptr_t rt_base, uint8_t *out_slot_id) {
                     g_evt_cycle ^= 1;
                 }
 
-                uintptr_t erdp = (uintptr_t)&g_evt_ring[g_evt_ring_index];
-                mmio_write32(rt_base, XHCI_RT_ERDP_LO, (uint32_t)(erdp & 0xFFFFFFFFu));
+                uintptr_t erdp_addr = (uintptr_t)&g_evt_ring[g_evt_ring_index];
+                mmio_write32(rt_base, XHCI_RT_ERDP_LO, (uint32_t)(erdp_addr & ~0xFu) | (1u << 3));
 #if UINTPTR_MAX > 0xFFFFFFFFu
-                mmio_write32(rt_base, XHCI_RT_ERDP_HI, (uint32_t)(erdp >> 32));
+                mmio_write32(rt_base, XHCI_RT_ERDP_HI, (uint32_t)(erdp_addr >> 32));
 #else
                 mmio_write32(rt_base, XHCI_RT_ERDP_HI, 0);
 #endif
@@ -456,7 +456,7 @@ static bool xhci_poll_cmd_complete(uintptr_t rt_base, uint8_t *out_slot_id) {
                     g_evt_cycle ^= 1;
                 }
                 uintptr_t erdp = (uintptr_t)&g_evt_ring[g_evt_ring_index];
-                mmio_write32(rt_base, XHCI_RT_ERDP_LO, (uint32_t)(erdp & 0xFFFFFFFFu));
+                mmio_write32(rt_base, XHCI_RT_ERDP_LO, (uint32_t)(erdp & 0xFFFFFFFFu) | (1u << 3));
 #if UINTPTR_MAX > 0xFFFFFFFFu
                 mmio_write32(rt_base, XHCI_RT_ERDP_HI, (uint32_t)(erdp >> 32));
 #else
@@ -486,10 +486,10 @@ static bool xhci_poll_transfer_complete(uintptr_t rt_base, uint8_t slot_id) {
                     g_evt_ring_index = 0;
                     g_evt_cycle ^= 1;
                 }
-                uintptr_t erdp = (uintptr_t)&g_evt_ring[g_evt_ring_index];
-                mmio_write32(rt_base, XHCI_RT_ERDP_LO, (uint32_t)(erdp & 0xFFFFFFFFu));
+                uintptr_t erdp_addr = (uintptr_t)&g_evt_ring[g_evt_ring_index];
+                mmio_write32(rt_base, XHCI_RT_ERDP_LO, (uint32_t)(erdp_addr & ~0xFu) | (1u << 3));
 #if UINTPTR_MAX > 0xFFFFFFFFu
-                mmio_write32(rt_base, XHCI_RT_ERDP_HI, (uint32_t)(erdp >> 32));
+                mmio_write32(rt_base, XHCI_RT_ERDP_HI, (uint32_t)(erdp_addr >> 32));
 #else
                 mmio_write32(rt_base, XHCI_RT_ERDP_HI, 0);
 #endif
@@ -503,7 +503,7 @@ static bool xhci_poll_transfer_complete(uintptr_t rt_base, uint8_t slot_id) {
                     g_evt_cycle ^= 1;
                 }
                 uintptr_t erdp = (uintptr_t)&g_evt_ring[g_evt_ring_index];
-                mmio_write32(rt_base, XHCI_RT_ERDP_LO, (uint32_t)(erdp & 0xFFFFFFFFu));
+                mmio_write32(rt_base, XHCI_RT_ERDP_LO, (uint32_t)(erdp & 0xFFFFFFFFu) | (1u << 3));
 #if UINTPTR_MAX > 0xFFFFFFFFu
                 mmio_write32(rt_base, XHCI_RT_ERDP_HI, (uint32_t)(erdp >> 32));
 #else
@@ -1416,10 +1416,10 @@ static int xhci_poll_transfer_event(uintptr_t rt_base, uint8_t *out_slot) {
         g_evt_ring_index = 0;
         g_evt_cycle ^= 1;
     }
-    uintptr_t erdp = (uintptr_t)&g_evt_ring[g_evt_ring_index];
-    mmio_write32(rt_base, XHCI_RT_ERDP_LO, (uint32_t)(erdp & 0xFFFFFFFFu));
+    uintptr_t erdp_addr = (uintptr_t)&g_evt_ring[g_evt_ring_index];
+    mmio_write32(rt_base, XHCI_RT_ERDP_LO, (uint32_t)(erdp_addr & ~0xFu) | (1u << 3));
 #if UINTPTR_MAX > 0xFFFFFFFFu
-    mmio_write32(rt_base, XHCI_RT_ERDP_HI, (uint32_t)(erdp >> 32));
+    mmio_write32(rt_base, XHCI_RT_ERDP_HI, (uint32_t)(erdp_addr >> 32));
 #else
     mmio_write32(rt_base, XHCI_RT_ERDP_HI, 0);
 #endif

--- a/src/Platform/x86/xhci.c
+++ b/src/Platform/x86/xhci.c
@@ -299,7 +299,7 @@ static void xhci_enumerate_port(uint8_t port_index);
 static const char *xhci_speed_name(uint32_t portsc);
 
 static void xhci_ring_doorbell(uintptr_t base, uint32_t db_off, uint32_t target) {
-    mmio_write32(base + db_off, XHCI_DB0 + target, 0);
+    mmio_write32(base + db_off, XHCI_DB0 + target * 4, 0);
 }
 
 static void xhci_ring_init(void) {
@@ -693,7 +693,7 @@ static void xhci_ep0_enqueue_status(uint8_t slot_id) {
 }
 
 static void xhci_ep0_ring_doorbell(uintptr_t base, uint32_t dboff, uint8_t slot_id) {
-    mmio_write32(base + dboff, XHCI_DB0 + slot_id, 1);
+    mmio_write32(base + dboff, XHCI_DB0 + (uint32_t)slot_id * 4, 1);
 }
 
 static void xhci_ep0_reset_ring(uint8_t slot_id) {
@@ -1488,7 +1488,7 @@ static void xhci_hid_submit(uintptr_t base, uint32_t dboff, xhci_hid_dev_t *dev)
     }
 
     xhci_hid_enqueue_interrupt_in(dev, (uintptr_t)dev->buf, dev->mps);
-    mmio_write32(base + dboff, XHCI_DB0 + dev->slot, dev->ep_id);
+    mmio_write32(base + dboff, XHCI_DB0 + (uint32_t)dev->slot * 4, dev->ep_id);
     dev->pending = true;
     dev->pending_tick = now;
     dev->last_submit_tick = now;
@@ -1539,10 +1539,10 @@ static bool xhci_msc_bulk_transfer(xhci_msc_dev_t *dev, uintptr_t base, uint32_t
     }
     if (in) {
         xhci_msc_enqueue_in(dev, (uintptr_t)buf, len);
-        mmio_write32(base + dboff, XHCI_DB0 + dev->slot, dev->bulk_in_ep_id);
+        mmio_write32(base + dboff, XHCI_DB0 + (uint32_t)dev->slot * 4, dev->bulk_in_ep_id);
     } else {
         xhci_msc_enqueue_out(dev, (uintptr_t)buf, len);
-        mmio_write32(base + dboff, XHCI_DB0 + dev->slot, dev->bulk_out_ep_id);
+        mmio_write32(base + dboff, XHCI_DB0 + (uint32_t)dev->slot * 4, dev->bulk_out_ep_id);
     }
     return xhci_poll_transfer_complete(rt_base, dev->slot);
 }
@@ -1553,7 +1553,7 @@ static bool xhci_uasp_transfer_cmd(xhci_msc_dev_t *dev, uintptr_t base, uint32_t
         return false;
     }
     xhci_uasp_enqueue_cmd(dev, (uintptr_t)buf, len);
-    mmio_write32(base + dboff, XHCI_DB0 + dev->slot, dev->uasp_cmd_out_ep_id);
+    mmio_write32(base + dboff, XHCI_DB0 + (uint32_t)dev->slot * 4, dev->uasp_cmd_out_ep_id);
     return xhci_poll_transfer_complete(rt_base, dev->slot);
 }
 
@@ -1567,13 +1567,13 @@ static bool xhci_uasp_transfer_data(xhci_msc_dev_t *dev, uintptr_t base, uint32_
             return false;
         }
         xhci_uasp_enqueue_data_in(dev, (uintptr_t)buf, len);
-        mmio_write32(base + dboff, XHCI_DB0 + dev->slot, dev->uasp_data_in_ep_id);
+        mmio_write32(base + dboff, XHCI_DB0 + (uint32_t)dev->slot * 4, dev->uasp_data_in_ep_id);
     } else {
         if (!dev->uasp_data_out_ep_id) {
             return false;
         }
         xhci_uasp_enqueue_data_out(dev, (uintptr_t)buf, len);
-        mmio_write32(base + dboff, XHCI_DB0 + dev->slot, dev->uasp_data_out_ep_id);
+        mmio_write32(base + dboff, XHCI_DB0 + (uint32_t)dev->slot * 4, dev->uasp_data_out_ep_id);
     }
     return xhci_poll_transfer_complete(rt_base, dev->slot);
 }
@@ -1584,7 +1584,7 @@ static bool xhci_uasp_transfer_status(xhci_msc_dev_t *dev, uintptr_t base, uint3
         return false;
     }
     xhci_uasp_enqueue_status(dev, (uintptr_t)buf, len);
-    mmio_write32(base + dboff, XHCI_DB0 + dev->slot, dev->uasp_status_in_ep_id);
+    mmio_write32(base + dboff, XHCI_DB0 + (uint32_t)dev->slot * 4, dev->uasp_status_in_ep_id);
     return xhci_poll_transfer_complete(rt_base, dev->slot);
 }
 

--- a/src/Platform/x86/xhci.c
+++ b/src/Platform/x86/xhci.c
@@ -688,7 +688,6 @@ static void xhci_ep0_enqueue_data_in(uint8_t slot_id, uintptr_t buf, uint32_t le
     trb->dword2 = len;
     trb->dword3 = (XHCI_TRB_TYPE_DATA_STAGE << XHCI_TRB_TYPE_SHIFT) |
                   (1u << 16) | /* IN */
-                  XHCI_TRB_IOC |
                   (g_ep0_cycle[slot_index] ? XHCI_TRB_CYCLE : 0);
 }
 
@@ -724,7 +723,6 @@ static bool xhci_ep0_control_no_data(uintptr_t base, uint32_t dboff, uintptr_t r
     if (!setup) {
         return false;
     }
-    xhci_ep0_reset_ring(slot_id);
     xhci_ep0_enqueue_setup(slot_id, setup);
     xhci_ep0_enqueue_status(slot_id);
     xhci_ep0_ring_doorbell(base, dboff, slot_id);
@@ -798,7 +796,6 @@ static bool xhci_ep0_set_configuration(uintptr_t base, uint32_t dboff, uintptr_t
         .wLength = 0
     };
 
-    xhci_ep0_reset_ring(slot_id);
     xhci_ep0_enqueue_setup(slot_id, &setup);
     xhci_ep0_enqueue_status(slot_id);
     xhci_ep0_ring_doorbell(base, dboff, slot_id);
@@ -817,7 +814,6 @@ static bool xhci_ep0_set_interface(uintptr_t base, uint32_t dboff, uintptr_t rt_
         .wLength = 0
     };
 
-    xhci_ep0_reset_ring(slot_id);
     xhci_ep0_enqueue_setup(slot_id, &setup);
     xhci_ep0_enqueue_status(slot_id);
     xhci_ep0_ring_doorbell(base, dboff, slot_id);
@@ -834,7 +830,6 @@ static bool xhci_ep0_set_protocol(uintptr_t base, uint32_t dboff, uintptr_t rt_b
         .wLength = 0
     };
 
-    xhci_ep0_reset_ring(slot_id);
     xhci_ep0_enqueue_setup(slot_id, &setup);
     xhci_ep0_enqueue_status(slot_id);
     xhci_ep0_ring_doorbell(base, dboff, slot_id);
@@ -850,7 +845,6 @@ static bool xhci_ep0_get_device_descriptor(uintptr_t base, uint32_t dboff, uintp
         .wLength = 18
     };
 
-    xhci_ep0_reset_ring(slot_id);
     xhci_ep0_enqueue_setup(slot_id, &setup);
     xhci_ep0_enqueue_data_in(slot_id, (uintptr_t)&g_ep0_buf[slot_id - 1][0], 18);
     xhci_ep0_enqueue_status(slot_id);
@@ -882,7 +876,6 @@ static bool xhci_ep0_get_config_descriptor(uintptr_t base, uint32_t dboff, uintp
     };
 
     memset(g_ep0_tmp_buf, 0, sizeof(g_ep0_tmp_buf));
-    xhci_ep0_reset_ring(slot_id);
     xhci_ep0_enqueue_setup(slot_id, &setup);
     xhci_ep0_enqueue_data_in(slot_id, (uintptr_t)&g_ep0_tmp_buf[0], 9);
     xhci_ep0_enqueue_status(slot_id);
@@ -903,7 +896,6 @@ static bool xhci_ep0_get_config_descriptor(uintptr_t base, uint32_t dboff, uintp
     if (total > 9) {
         setup.wLength = total;
         memset(g_ep0_tmp_buf, 0, sizeof(g_ep0_tmp_buf));
-        xhci_ep0_reset_ring(slot_id);
         xhci_ep0_enqueue_setup(slot_id, &setup);
         xhci_ep0_enqueue_data_in(slot_id, (uintptr_t)&g_ep0_tmp_buf[0], total);
         xhci_ep0_enqueue_status(slot_id);
@@ -1942,7 +1934,6 @@ static bool xhci_msc_get_max_lun(xhci_msc_dev_t *dev, uintptr_t base, uint32_t d
     };
 
     memset(g_ep0_buf[slot_id - 1], 0, sizeof(g_ep0_buf[slot_id - 1]));
-    xhci_ep0_reset_ring(slot_id);
     xhci_ep0_enqueue_setup(slot_id, &setup);
     xhci_ep0_enqueue_data_in(slot_id, (uintptr_t)&g_ep0_buf[slot_id - 1][0], 1);
     xhci_ep0_enqueue_status(slot_id);

--- a/src/Platform/x86/xhci.h
+++ b/src/Platform/x86/xhci.h
@@ -7,6 +7,7 @@
 bool xhci_init_x86(void);
 void xhci_poll_hid_x86(void);
 bool xhci_hid_available(void);
+bool xhci_has_absolute_pointer(void);
 bool xhci_msc_available(void);
 OSErr xhci_msc_get_info(uint32_t *block_size, uint64_t *block_count, bool *read_only);
 OSErr xhci_msc_get_info_lun(uint8_t lun, uint32_t *block_size, uint64_t *block_count, bool *read_only);

--- a/src/System71StdLib.c
+++ b/src/System71StdLib.c
@@ -1831,7 +1831,8 @@ static const SysLogTag kLogTagTable[] = {
     { "PaintBehind", kLogModuleWindow, kLogLevelTrace },
     { "MEM", kLogModuleMemory, kLogLevelInfo },
     { "FM", kLogModuleFont, kLogLevelDebug },
-    { "M68K", kLogModuleCPU, kLogLevelDebug }
+    { "M68K", kLogModuleCPU, kLogLevelDebug },
+    { "XHCI", kLogModulePlatform, kLogLevelWarn }
 };
 
 
@@ -1956,6 +1957,14 @@ static void SysLogFormatAndSend(const char* fmt, va_list args) {
                 const char* hex_digits = "0123456789abcdef";
                 buffer[buf_idx++] = hex_digits[(val >> 4) & 0xF];
                 if (buf_idx < 255) buffer[buf_idx++] = hex_digits[val & 0xF];
+                p += 3;
+            }
+            else if (*p == '0' && *(p + 1) == '4' && *(p + 2) == 'x') {
+                unsigned int val = va_arg(args, unsigned int);
+                const char* hex_digits = "0123456789abcdef";
+                for (int i = 3; i >= 0 && buf_idx < 255; --i) {
+                    buffer[buf_idx++] = hex_digits[(val >> (i * 4)) & 0xF];
+                }
                 p += 3;
             }
             else if (*p == '0' && *(p + 1) == '8' && *(p + 2) == 'x') {

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,7 @@ extern void DoMenuCommand(short menuID, short item);
 #endif
 
 #include "Platform/include/network.h"
+#include "Platform/include/input.h"
 #if defined(__i386__) || defined(__x86_64__)
 #include "Platform/x86/idt.h"
 #include "Platform/x86/pic.h"
@@ -1863,6 +1864,13 @@ void kernel_main(uint32_t magic, uint32_t* mb2_info) {
         xhci_init_x86();
     } else {
         serial_puts("KERNEL: xHCI HID already present\n");
+    }
+
+    if (xhci_has_absolute_pointer()) {
+        serial_puts("KERNEL: USB tablet detected — switching mouse source\n");
+        hal_input_set_mouse_source(kMouseSourceUSBTablet);
+    } else {
+        serial_puts("KERNEL: No USB tablet found — using PS/2 mouse\n");
     }
 
     /* Keep IRQs disabled for now; polling paths are stable. */

--- a/src/main.c
+++ b/src/main.c
@@ -1916,7 +1916,7 @@ void kernel_main(uint32_t magic, uint32_t* mb2_info) {
 
         /* Throttle ONLY cursor drawing, not event processing */
         cursor_update_counter++;
-        if (cursor_update_counter < 50) {
+        if (cursor_update_counter < 2) {
             /* Skip only the cursor drawing, but continue to process events below */
             goto skip_cursor_drawing;
         }


### PR DESCRIPTION
Summary                                                                                                                                                    

  - Fix xHCI doorbell register addressing (slot * 4 stride per spec §5.6)
  - Fix ERDP writes to clear Event Handler Busy bit (§5.5.2.3.3)
  - Fix input/device/endpoint context layout (Add flags, slot entries, EP DWord ordering, DCS, context sizing per §6.2)
  - Remove redundant EP0 ring resets and data-stage IOC
  - Fix HID interrupt transfer ring wrapping (link TRB before data TRB)
  - Fix HID enumeration: defer set_interface/set_protocol, preserve slot context
  - Switch HID polling to event-driven re-submit model
  - Add USB tablet absolute pointer support with PS/2 conflict resolution
  - Add XHCI debug logging and %04x format specifier
  - Reduce cursor drawing throttle for responsive tracking (XHCI sends too many events for the original limiter)